### PR TITLE
Support for Redis Sentinel 

### DIFF
--- a/src/Bravo3/Orm/Drivers/Redis/RedisDriver.php
+++ b/src/Bravo3/Orm/Drivers/Redis/RedisDriver.php
@@ -82,7 +82,7 @@ class RedisDriver implements DriverInterface
             if (!empty($masters) && !empty($slaves)) {
                 $options = array_merge($options ?: [], ['replication' => true]);
             }
-die(var_dump($redis_connections, $options));
+
             $this->client = new Client($redis_connections, $options);
         } else {
             $this->client = new Client($params, $options);

--- a/src/Bravo3/Orm/Drivers/Redis/RedisDriver.php
+++ b/src/Bravo3/Orm/Drivers/Redis/RedisDriver.php
@@ -64,8 +64,17 @@ class RedisDriver implements DriverInterface
                 $slaves = $this->sentinel->findSlaves();
             }
 
-            $params = array_merge(
-                $masters,
+            // Merge fixed connections to redis with discovered masters
+            if (is_array($params)) {
+                $redis_connections = array_merge(
+                    $params,
+                    $masters
+                );
+            }
+
+            // Merge additional slaves discovered
+            $redis_connections = array_merge(
+                $redis_connections,
                 $slaves
             );
 
@@ -73,8 +82,8 @@ class RedisDriver implements DriverInterface
             if (!empty($masters) && !empty($slaves)) {
                 $options = array_merge($options ?: [], ['replication' => true]);
             }
-
-            $this->client = new Client($params, $options);
+die(var_dump($redis_connections, $options));
+            $this->client = new Client($redis_connections, $options);
         } else {
             $this->client = new Client($params, $options);
         }

--- a/src/Bravo3/Orm/Drivers/Redis/RedisDriver.php
+++ b/src/Bravo3/Orm/Drivers/Redis/RedisDriver.php
@@ -36,7 +36,7 @@ class RedisDriver implements DriverInterface
     /**
      * @var SentinelMonitor
      */
-    private $sentinel = null;
+    protected $sentinel = null;
 
     /**
      * @var ScoreNormaliser

--- a/src/Bravo3/Orm/Drivers/Redis/SentinelMonitor.php
+++ b/src/Bravo3/Orm/Drivers/Redis/SentinelMonitor.php
@@ -131,10 +131,19 @@ class SentinelMonitor
     protected function validateConnection($host_info)
     {
         if ('master' === $host_info['role-reported']) {
+
+            // Verify reported master is up based on parameters discovered
+            // by sentinel
             $down_after_interval = (int) $host_info['down-after-milliseconds'];
             $last_ok_since = (int) $host_info['last-ok-ping-reply'];
 
             if ($last_ok_since > $down_after_interval) {
+                return false;
+            }
+        } elseif ('slave' === $host_info['role-reported']) {
+
+            // If slave status is disconnected ignore
+            if (!(false === strpos($host_info['flags'], 'disconnected')) {
                 return false;
             }
         }

--- a/src/Bravo3/Orm/Drivers/Redis/SentinelMonitor.php
+++ b/src/Bravo3/Orm/Drivers/Redis/SentinelMonitor.php
@@ -143,7 +143,7 @@ class SentinelMonitor
         } elseif ('slave' === $host_info['role-reported']) {
 
             // If slave status is disconnected ignore
-            if (!(false === strpos($host_info['flags'], 'disconnected')) {
+            if (!(false === strpos($host_info['flags'], 'disconnected'))) {
                 return false;
             }
         }

--- a/src/Bravo3/Orm/Drivers/Redis/SentinelMonitor.php
+++ b/src/Bravo3/Orm/Drivers/Redis/SentinelMonitor.php
@@ -17,11 +17,11 @@ class SentinelMonitor
      * If more than one sentinel server parameters are provided, the first
      * sentinel that connects will be used for retrival of information.
      *
-     * @param mixed $params
+     * @param array $params
      */
     public function __construct($connection_params = null)
     {
-        foreach($connection_params as $connection) {
+        foreach ($connection_params as $connection) {
             $this->client = new Client($connection);
 
             // Usable connection is found
@@ -40,8 +40,7 @@ class SentinelMonitor
      */
     public function findSentinels($master_name = 'mymaster')
     {
-        $sentinels = $this->client->sentinel('sentinels', $master_name);
-        return $sentinels;
+        return $this->client->sentinel('sentinels', $master_name);
     }
 
     /**
@@ -52,8 +51,10 @@ class SentinelMonitor
      */
     public function findMasters()
     {
-        $masters = $this->client->sentinel('masters');
-        return $this->getConnectionParams($masters, 'master');
+        return $this->getConnectionParams(
+            $this->client->sentinel('masters'),
+            'master'
+        );
     }
 
     /**
@@ -73,7 +74,6 @@ class SentinelMonitor
         if (null !== $master_name) {
             $slaves = $this->client->sentinel('slaves', $master_name);
         } else {
-
             // Find out slaves attached to each master instance
             foreach ($this->findMasters() as $master) {
                 $name = $master['name'];
@@ -131,7 +131,6 @@ class SentinelMonitor
     protected function validateConnection($host_info)
     {
         if ('master' === $host_info['role-reported']) {
-
             // Verify reported master is up based on parameters discovered
             // by sentinel
             $down_after_interval = (int) $host_info['down-after-milliseconds'];
@@ -141,7 +140,6 @@ class SentinelMonitor
                 return false;
             }
         } elseif ('slave' === $host_info['role-reported']) {
-
             // If slave status is disconnected ignore
             if (!(false === strpos($host_info['flags'], 'disconnected'))) {
                 return false;

--- a/src/Bravo3/Orm/Drivers/Redis/SentinelMonitor.php
+++ b/src/Bravo3/Orm/Drivers/Redis/SentinelMonitor.php
@@ -1,0 +1,144 @@
+<?php
+namespace Bravo3\Orm\Drivers\Redis;
+
+use Bravo3\Orm\Drivers\Common\Command;
+use Predis\Client;
+
+class SentinelMonitor
+{
+    /**
+     * @var Client
+     */
+    protected $client;
+
+    /**
+     * Create a new Sentinel Monitor.
+     *
+     * If more than one sentinel server parameters are provided, the first
+     * sentinel that connects will be used for retrival of information.
+     *
+     * @param mixed $params
+     */
+    public function __construct($connection_params = null)
+    {
+        foreach($connection_params as $connection) {
+            $this->client = new Client($connection);
+
+            // Usable connection is found
+            if ($this->client->isConnected()) {
+                break;
+            }
+        }
+    }
+
+    /**
+     * Return an array of SENTINEL servers in the form that can be
+     * passed to Predis Client.
+     *
+     * @param  string $master_name
+     * @return array
+     */
+    public function findSentinels($master_name = 'mymaster')
+    {
+        $sentinels = $this->client->sentinel('sentinels', $master_name);
+        return $sentinels;
+    }
+
+    /**
+     * Return an array of MASTER servers in the form that can be
+     * passed to Predis Client.
+     *
+     * @return array
+     */
+    public function findMasters()
+    {
+        $masters = $this->client->sentinel('masters');
+        return $this->getConnectionParams($masters, 'master');
+    }
+
+    /**
+     * Return an array of SLAVE servers in the form that can be
+     * passed to Predis Client.
+     *
+     * If $master_name parameter is not set this function will return
+     * slaves attached to all connected master servers.
+     *
+     * @param  string $master_name
+     * @return array
+     */
+    public function findSlaves($master_name = null)
+    {
+        $slaves = [];
+
+        if (null !== $master_name) {
+            $slaves = $this->client->sentinel('slaves', $master_name);
+        } else {
+
+            // Find out slaves attached to each master instance
+            foreach ($this->findMasters() as $master) {
+                $name = $master['name'];
+                $slaves = array_merge(
+                    $slaves,
+                    $this->client->sentinel('slaves', $name)
+                );
+            }
+        }
+
+        return $this->getConnectionParams($slaves, 'slave');
+    }
+
+    /**
+     * Return an array of formatted output from Sentinel to be used
+     * as Redis connection parameters for the Predis client.
+     *
+     * Inactive connection parameters will be removed if sentinel reports
+     * services as inactive.
+     *
+     * @param  array $sentinel_output
+     * @return array|null
+     */
+    protected function getConnectionParams($sentinel_output, $alias = null)
+    {
+        $connections = [];
+
+        foreach ($sentinel_output as $params) {
+            $connection = [
+                'name'  => $params['name'],
+                'host'  => $params['ip'],
+                'port'  => $params['port'],
+            ];
+
+            if (!empty($alias)) {
+                $connection['alias'] = $alias;
+            }
+
+            // Validate connection params adding
+            if ($this->validateConnection($params)) {
+                $connections[] = $connection;
+            }
+        }
+
+        return $connections;
+    }
+
+    /**
+     * Function returns true if connection to redis host is
+     * accessible based on the output received from Sentinel.
+     *
+     * @param  array $host_info
+     * @return bool
+     */
+    protected function validateConnection($host_info)
+    {
+        if ('master' === $host_info['role-reported']) {
+            $down_after_interval = (int) $host_info['down-after-milliseconds'];
+            $last_ok_since = (int) $host_info['last-ok-ping-reply'];
+
+            if ($last_ok_since > $down_after_interval) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
WIP: Checking connection status is only added for master instances.

SentinelMonitor class is responsible for communicating with the sentinel
server in regard to finding out master and slave instances of redis
running.

Modified RedisDriver to figure out running redis instances from Sentinel
service.
