### PR TITLE
bugfix/relying-on-disconnected-flag

### DIFF
--- a/src/Bravo3/Orm/Drivers/Redis/RedisDriver.php
+++ b/src/Bravo3/Orm/Drivers/Redis/RedisDriver.php
@@ -64,6 +64,9 @@ class RedisDriver implements DriverInterface
                 $slaves = $this->sentinel->findSlaves();
             }
 
+            // Initialise redis connections array
+            $redis_connections = [];
+
             // Merge fixed connections to redis with discovered masters
             if (is_array($params)) {
                 $redis_connections = array_merge(

--- a/src/Bravo3/Orm/Drivers/Redis/SentinelMonitor.php
+++ b/src/Bravo3/Orm/Drivers/Redis/SentinelMonitor.php
@@ -140,8 +140,20 @@ class SentinelMonitor
                 return false;
             }
         } elseif ('slave' === $host_info['role-reported']) {
+
             // If slave status is disconnected ignore
             if (!(false === strpos($host_info['flags'], 'disconnected'))) {
+                return false;
+            }
+
+            // If slave is subjectively down ignore
+            // Reference: http://redis.io/topics/sentinel#pubsub-messages
+            if (!(false === strpos($host_info['flags'], 's_down'))) {
+                return false;
+            }
+
+            // If slave is objectively down ignore
+            if (!(false === strpos($host_info['flags'], 'o_down'))) {
                 return false;
             }
         }


### PR DESCRIPTION
Added s_down, o_down as down flags for redis instances along with immediate disconnected flag.

It looks like disconnected flag becomes active when an instance is immediately not contactable but after instance down timeout the flags array gets two more flags depending on their state which are s_down (subjectively down) or o_down (objectively down).
