### PR TITLE
Added sorted tables, naming sort indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,9 +212,13 @@ Known Issues
 
 Change Log
 ----------
+### 0.4.3
+* Added the ability to perform sorted, conditional queries on all items in a table
+* Added the ability to name sorted queries, allowing different configurations of conditions on the same column
+
 ### 0.3.13
-* changed logic for retrieving entities. If nothing found (during writing) it will generate a new instance of the entity with the correct id
-* retrieving an entity with missing relatives will now return blank new instances of the relatives
+* Changed logic for retrieving entities. If nothing found (during writing) it will generate a new instance of the entity with the correct id
+* Retrieving an entity with missing relatives will now return blank new instances of the relatives
 
 ### 0.3.0
 * Added ref tables to maintain non-reciprocated relationships

--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -4,7 +4,7 @@ Queries
 Sorted Queries
 --------------
 The sorted query is the most efficient way to perform a query. Sorted queries work on a z-index and can be sorted in
-ascending or descending order, as well as efficiently select a range for the query.
+ascending or descending order, as well as efficiently select a range for the query and apply conditions on the query.
 
 Sorted queries however must work on a numeric score for sorting, thus only the following field types can be properly
 sorted:
@@ -60,8 +60,10 @@ The solution is to create conditions on your sort indices:
      *          @Orm\Sortable(column="last_modified", conditions={
      *              @Orm\Condition(column="published", value=true),
      *              @Orm\Condition(column="id", value=50, comparison=">")
-     *          }), "id"
-     *      })
+     *          }), 
+     *          "id"
+     *      }
+     * )
      */
     protected $articles;
 
@@ -84,11 +86,29 @@ You can also test your condition against the value returned by a method call:
      */
     protected $articles;
 
-It's important to note that you cannot retrieve an unfiltered version of the `last_modified` index now, the database
-will only add articles to the index if the conditions are met. 
+### Multiple Conditions
+When specifying sortable columns, by default we name the index according to the column name. However, if you require
+multiple conditions on the same column you must specify a name:
 
-When using annotation mapping, you can add items to the `sortable_by` list either by a string or a @Sortable 
-annotation, however you can only add conditions when using @Sortable with @Condition annotations.
+    /**
+     * @var Article[]
+     * @Orm\OneToMany(
+     *      target="Article",
+     *      inversed_by="category",
+     *      sortable_by={
+     *          @Orm\Sortable(column="last_modified", name="last_modified_unpublished", conditions={
+     *              @Orm\Condition(method="isPublished", value=false)
+     *          }),
+     *          @Orm\Sortable(column="last_modified", name="last_modified_published" conditions={
+     *              @Orm\Condition(method="isPublished", value=true)
+     *          })
+     *      })
+     */
+    protected $articles;
+
+### Note on Syntax
+When using annotation mapping, you can add items to the `sortable_by` list either by a string or a `@Sortable` 
+annotation, however you can only add conditions and name the index when using the full `@Sortable` annotation syntax.
 
 Indexed Queries
 ---------------

--- a/src/Bravo3/Orm/Annotations/Entity.php
+++ b/src/Bravo3/Orm/Annotations/Entity.php
@@ -16,4 +16,9 @@ class Entity
      * @var array
      */
     public $indices = [];
+
+    /**
+     * @var array
+     */
+    public $sortable_by = [];
 }

--- a/src/Bravo3/Orm/Annotations/Sortable.php
+++ b/src/Bravo3/Orm/Annotations/Sortable.php
@@ -10,6 +10,11 @@ class Sortable
     /**
      * @var string
      */
+    public $name = null;
+
+    /**
+     * @var string
+     */
     public $column;
 
     /**

--- a/src/Bravo3/Orm/KeySchemes/KeySchemeInterface.php
+++ b/src/Bravo3/Orm/KeySchemes/KeySchemeInterface.php
@@ -51,4 +51,13 @@ interface KeySchemeInterface
      * @return string
      */
     public function getSortIndexKey(Relationship $relationship, $sort_field, $id);
+
+    /**
+     * Get the key for a sort index on a table
+     *
+     * @param string $table_name Name of table containing sorted entity list
+     * @param string $sort_field Sortable field on the table
+     * @return string
+     */
+    public function getTableSortKey($table_name, $sort_field);
 }

--- a/src/Bravo3/Orm/KeySchemes/StandardKeyScheme.php
+++ b/src/Bravo3/Orm/KeySchemes/StandardKeyScheme.php
@@ -126,4 +126,19 @@ class StandardKeyScheme implements KeySchemeInterface
                $relationship->getName().$this->delimiter.
                $sort_field;
     }
+
+    /**
+     * Get the key for a sort index on a table
+     *
+     * @param string $table_name Name of table containing sorted entity list
+     * @param string $sort_field Sortable field on the table
+     * @return string
+     */
+    public function getTableSortKey($table_name, $sort_field)
+    {
+        // srt:category:title
+        return static::SORT_NAMESPACE.$this->delimiter.
+               $table_name.$this->delimiter.
+               $sort_field;
+    }
 }

--- a/src/Bravo3/Orm/Mappers/Metadata/Entity.php
+++ b/src/Bravo3/Orm/Mappers/Metadata/Entity.php
@@ -34,6 +34,11 @@ class Entity
     protected $indices = [];
 
     /**
+     * @var Sortable[]
+     */
+    protected $sortables = [];
+
+    /**
      * Used to lookup the property that matches a getter/setter function
      *
      * @var array
@@ -309,5 +314,56 @@ class Entity
         }
 
         return null;
+    }
+
+    /**
+     * Get Sortables
+     *
+     * @return Sortable[]
+     */
+    public function getSortables()
+    {
+        return $this->sortables;
+    }
+
+    /**
+     * Set Sortables
+     *
+     * @param Sortable[] $sortables
+     * @return $this
+     */
+    public function setSortables(array $sortables)
+    {
+        $this->sortables = $sortables;
+        return $this;
+    }
+
+    /**
+     * Get a table sortable by name
+     *
+     * @param string $name
+     * @return Sortable|null
+     */
+    public function getSortableByName($name)
+    {
+        foreach ($this->sortables as $sortable) {
+            if ($sortable->getName() == $name) {
+                return $sortable;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Add a sortable to the table metadata
+     *
+     * @param Sortable $sortable
+     * @return $this
+     */
+    public function addSortable(Sortable $sortable)
+    {
+        $this->sortables[] = $sortable;
+        return $this;
     }
 }

--- a/src/Bravo3/Orm/Mappers/Metadata/Sortable.php
+++ b/src/Bravo3/Orm/Mappers/Metadata/Sortable.php
@@ -6,6 +6,11 @@ class Sortable
     /**
      * @var string
      */
+    protected $name;
+
+    /**
+     * @var string
+     */
     protected $column;
 
     /**
@@ -13,8 +18,9 @@ class Sortable
      */
     protected $conditions;
 
-    public function __construct($column, array $conditions = [])
+    public function __construct($column, array $conditions = [], $name = null)
     {
+        $this->name       = $name ?: $column;
         $this->column     = $column;
         $this->conditions = $conditions;
     }
@@ -72,6 +78,28 @@ class Sortable
     public function addCondition(Condition $condition)
     {
         $this->conditions[] = $condition;
+        return $this;
+    }
+
+    /**
+     * Get Name
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Set Name
+     *
+     * @param string $name
+     * @return $this
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
         return $this;
     }
 }

--- a/src/Bravo3/Orm/Query/SortedTableQuery.php
+++ b/src/Bravo3/Orm/Query/SortedTableQuery.php
@@ -1,0 +1,24 @@
+<?php
+namespace Bravo3\Orm\Query;
+
+use Bravo3\Orm\Enum\Direction;
+
+class SortedTableQuery extends SortedQuery
+{
+    /**
+     * @param string    $class_name Class name of table to query
+     * @param string    $sort_by    Sort by column
+     * @param Direction $direction  Assumes ascending if omitted
+     * @param int       $start      Start index (inclusive), null/0 for beginning of set
+     * @param int       $end        Stop index (inclusive), null/-1 for end of set, -2 for penultimate record
+     */
+    public function __construct(
+        $class_name,
+        $sort_by,
+        Direction $direction = null,
+        $start = null,
+        $end = null
+    ) {
+        parent::__construct($class_name, null, $sort_by, $direction, $start, $end);
+    }
+}

--- a/src/Bravo3/Orm/Services/EntityManager.php
+++ b/src/Bravo3/Orm/Services/EntityManager.php
@@ -220,6 +220,7 @@ class EntityManager
 
         $this->getRelationshipManager()->persistRelationships($entity, $metadata, $reader, $id);
         $this->getIndexManager()->persistIndices($entity, $metadata, $reader, $id);
+        $this->getQueryManager()->persistTableQueries($entity, $metadata, $reader, $id);
 
         if ($entity instanceof OrmProxyInterface) {
             $entity->setEntityPersisted($id);
@@ -279,6 +280,7 @@ class EntityManager
         // Delete relationships & indices
         $this->getRelationshipManager()->deleteRelationships($entity, $metadata, $reader, $local_id);
         $this->getIndexManager()->deleteIndices($entity, $metadata, $reader, $local_id);
+        $this->getQueryManager()->deleteTableQueries($entity, $metadata, $reader, $local_id);
 
         return $this->getProxy();
     }
@@ -404,7 +406,7 @@ class EntityManager
     /**
      * Will force a database update of an entity
      *
-     * This will also convert a fresh entity to an OrmProxyInterface
+     * This will also convert a fresh entity to an OrmProxyInterface.
      *
      * @param object $entity
      * @return object

--- a/src/Bravo3/Orm/Services/RelationshipManager.php
+++ b/src/Bravo3/Orm/Services/RelationshipManager.php
@@ -105,7 +105,7 @@ class RelationshipManager extends AbstractManagerUtility
             foreach ($relationship->getSortableBy() as $sortable) {
                 $forward_sort_key = $this->getKeyScheme()->getSortIndexKey(
                     $relationship,
-                    $sortable->getColumn(),
+                    $sortable->getName(),
                     $local_id
                 );
                 $this->getDriver()->clearSortedIndex($forward_sort_key);
@@ -134,7 +134,7 @@ class RelationshipManager extends AbstractManagerUtility
         foreach ($inverse_relationship->getSortableBy() as $sortable) {
             $sort_key = $this->getKeyScheme()->getSortIndexKey(
                 $inverse_relationship,
-                $sortable->getColumn(),
+                $sortable->getName(),
                 $foreign_id
             );
             $this->getDriver()->removeSortedIndex($sort_key, $local_id);
@@ -242,7 +242,7 @@ class RelationshipManager extends AbstractManagerUtility
 
         $this->getDriver()->debugLog('@Setting forward sort indices for "'.$local_id.'"');
         foreach ($relationship->getSortableBy() as $sortable) {
-            $key = $this->getKeyScheme()->getSortIndexKey($relationship, $sortable->getColumn(), $local_id);
+            $key = $this->getKeyScheme()->getSortIndexKey($relationship, $sortable->getName(), $local_id);
             $this->getDriver()->clearSortedIndex($key);
 
             foreach ($value as $entity) {
@@ -304,7 +304,7 @@ class RelationshipManager extends AbstractManagerUtility
             // If the inverted relationship has sorting, remove the local from the sorted index
             foreach ($inverse_relationship->getSortableBy() as $sortable) {
                 $this->getDriver()->removeSortedIndex(
-                    $this->getKeyScheme()->getSortIndexKey($inverse_relationship, $sortable->getColumn(), $foreign_id),
+                    $this->getKeyScheme()->getSortIndexKey($inverse_relationship, $sortable->getName(), $foreign_id),
                     $local_id
                 );
             }
@@ -339,7 +339,7 @@ class RelationshipManager extends AbstractManagerUtility
 
                 // Add inverse index
                 $this->getDriver()->addSortedIndex(
-                    $this->getKeyScheme()->getSortIndexKey($inverse_relationship, $sortable->getColumn(), $foreign_id),
+                    $this->getKeyScheme()->getSortIndexKey($inverse_relationship, $sortable->getName(), $foreign_id),
                     $reader->getPropertyValue($sortable->getColumn()),
                     $local_id
                 );
@@ -465,7 +465,7 @@ class RelationshipManager extends AbstractManagerUtility
             foreach ($relationship->getSortableBy() as $sortable) {
                 $sort_key = $this->getKeyScheme()->getSortIndexKey(
                     $relationship,
-                    $sortable->getColumn(),
+                    $sortable->getName(),
                     $ref->getEntityId()
                 );
                 $this->getDriver()->removeSortedIndex($sort_key, $local_id);
@@ -500,7 +500,7 @@ class RelationshipManager extends AbstractManagerUtility
             foreach ($inverse_relationship->getSortableBy() as $sortable) {
                 $index_key = $this->getKeyScheme()->getSortIndexKey(
                     $inverse_relationship,
-                    $sortable->getColumn(),
+                    $sortable->getName(),
                     $foreign_id
                 );
 
@@ -580,7 +580,7 @@ class RelationshipManager extends AbstractManagerUtility
         foreach ($inverse_relationship->getSortableBy() as $sortable) {
             $sort_key = $this->getKeyScheme()->getSortIndexKey(
                 $inverse_relationship,
-                $sortable->getColumn(),
+                $sortable->getName(),
                 $old_value
             );
             $this->getDriver()->removeSortedIndex($sort_key, $source_id);

--- a/tests/Bravo3/Orm/Tests/Entities/Conditional/Category.php
+++ b/tests/Bravo3/Orm/Tests/Entities/Conditional/Category.php
@@ -33,7 +33,11 @@ class Category
      *          @Sortable(column="last_modified", conditions={
      *              @Condition(column="published", value=true),
      *              @Condition(column="id", value=50, comparison=">")
-     *          }), "id"
+     *          }),
+     *          "id",
+     *          @Sortable(column="last_modified", conditions={
+     *              @Condition(column="published", value=true),
+     *          }, name="last_modified_all")
      *      })
      */
     protected $articles;

--- a/tests/Bravo3/Orm/Tests/Entities/SortedUser.php
+++ b/tests/Bravo3/Orm/Tests/Entities/SortedUser.php
@@ -1,0 +1,104 @@
+<?php
+namespace Bravo3\Orm\Tests\Entities;
+
+use Bravo3\Orm\Annotations\Column;
+use Bravo3\Orm\Annotations\Condition;
+use Bravo3\Orm\Annotations\Entity;
+use Bravo3\Orm\Annotations\Id;
+use Bravo3\Orm\Annotations\Sortable;
+
+/**
+ * @Entity(sortable_by={
+ *      @Sortable(name="name_active", column="name", conditions={
+ *          @Condition(column="active", value=true)
+ *      }),
+ *      @Sortable(name="name_all", column="name")
+ * })
+ */
+class SortedUser
+{
+    /**
+     * @var int
+     * @Column(type="int")
+     * @Id()
+     */
+    protected $id;
+
+    /**
+     * @var string
+     * @Column(type="string")
+     */
+    protected $name;
+
+    /**
+     * @var bool
+     * @Column(type="bool")
+     */
+    protected $active;
+
+    /**
+     * Get Id
+     *
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Set Id
+     *
+     * @param int $id
+     * @return $this
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    /**
+     * Get Name
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Set Name
+     *
+     * @param string $name
+     * @return $this
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    /**
+     * Get Active
+     *
+     * @return boolean
+     */
+    public function getActive()
+    {
+        return $this->active;
+    }
+
+    /**
+     * Set Active
+     *
+     * @param boolean $active
+     * @return $this
+     */
+    public function setActive($active)
+    {
+        $this->active = (bool)$active;
+        return $this;
+    }
+}

--- a/tests/Bravo3/Orm/Tests/Indices/SortedQueryTest.php
+++ b/tests/Bravo3/Orm/Tests/Indices/SortedQueryTest.php
@@ -9,8 +9,6 @@ use Bravo3\Orm\Tests\Entities\OneToMany\Category;
 
 class SortedQueryTest extends AbstractOrmTest
 {
-    const ARTICLE = 'Bravo3\Orm\Tests\Entities\OneToMany\Article';
-
     public function testPersist()
     {
         // Persist a forward relationship
@@ -46,7 +44,7 @@ class SortedQueryTest extends AbstractOrmTest
 
         // Update the category's article list by removing an entity on the inverse side
         /** @var Article $article */
-        $article = $em->retrieve(self::ARTICLE, 201);
+        $article = $em->retrieve(Article::class, 201);
         $article->setCanonicalCategory($category2);
         $em->persist($article)->flush();
 
@@ -123,7 +121,7 @@ class SortedQueryTest extends AbstractOrmTest
         $this->assertEquals('Art 615', $article->getTitle());
 
         // Modify an entity's sort-by column
-        $article = $em->retrieve(self::ARTICLE, 609);
+        $article = $em->retrieve(Article::class, 609);
         $time    = $article->getSortDate();
         $time->modify('+1 day');
         $article->setSortDate($time);

--- a/tests/Bravo3/Orm/Tests/Indices/SortedTableTest.php
+++ b/tests/Bravo3/Orm/Tests/Indices/SortedTableTest.php
@@ -1,0 +1,36 @@
+<?php
+namespace Bravo3\Orm\Tests\Indices;
+
+use Bravo3\Orm\Query\SortedTableQuery;
+use Bravo3\Orm\Tests\AbstractOrmTest;
+use Bravo3\Orm\Tests\Entities\SortedUser;
+
+class SortedTableTest extends AbstractOrmTest
+{
+    public function testTableSorting()
+    {
+        $em = $this->getEntityManager();
+
+        $user1 = new SortedUser();
+        $user1->setId(1)->setName('User 1')->setActive(true);
+
+        $user2 = new SortedUser();
+        $user2->setId(2)->setName('User 2')->setActive(false);
+
+        $user3 = new SortedUser();
+        $user3->setId(3)->setName('User 3')->setActive(true);
+
+        $em->persist($user1)->persist($user2)->persist($user3)->flush();
+
+        $query = $em->sortedQuery(new SortedTableQuery(SortedUser::class, 'name_all'));
+        $this->assertEquals(3, $query->count());
+        $this->assertEquals('User 1', $query[0]->getName());
+        $this->assertEquals('User 2', $query[1]->getName());
+        $this->assertEquals('User 3', $query[2]->getName());
+
+        $query = $em->sortedQuery(new SortedTableQuery(SortedUser::class, 'name_active'));
+        $this->assertEquals(2, $query->count());
+        $this->assertEquals('User 1', $query[0]->getName());
+        $this->assertEquals('User 3', $query[1]->getName());
+    }
+}

--- a/tests/Bravo3/Orm/Tests/Relationships/ConditionalTest.php
+++ b/tests/Bravo3/Orm/Tests/Relationships/ConditionalTest.php
@@ -51,6 +51,9 @@ class ConditionalTest extends AbstractOrmTest
         $articles = $em->sortedQuery(new SortedQuery($category, 'articles', 'last_modified'));
         $this->assertCount(4, $articles);
 
+        $articles = $em->sortedQuery(new SortedQuery($category, 'articles', 'last_modified_all'));
+        $this->assertCount(10, $articles);
+
         $articles = $em->sortedQuery(new SortedQuery($category, 'articles', 'id'));
         $this->assertCount(11, $articles);
 


### PR DESCRIPTION
Adds the ability to have a sorted query on the table itself, preventing the need for a root entity in order to retrieve a (sorted and/or conditional) list of all items in a table.

Also adds naming to sort indices, allowing you to have multiple configurations of conditional statements on the same column.
