### PR TITLE
Switch to ignore automatic slave discovery

### DIFF
--- a/src/Bravo3/Orm/Drivers/Redis/PredisClientFactory.php
+++ b/src/Bravo3/Orm/Drivers/Redis/PredisClientFactory.php
@@ -25,6 +25,14 @@ class PredisClientFactory
      */
     public static function create($params = null, $options = null, $sentinel_params = null)
     {
+        $discover_slaves = false;
+
+        // Make sure slave discovery from sentinels flag is set
+        if (is_array($options) && isset($options['discover_slaves'])) {
+            $discover_slaves = (bool) $options['discover_slaves'];
+            unset($options['discover_slaves']);
+        }
+
         // If sentinel params are defined use sentinel to find out about
         // redis servers.
         if (!empty($sentinel_params)) {

--- a/src/Bravo3/Orm/Drivers/Redis/PredisClientFactory.php
+++ b/src/Bravo3/Orm/Drivers/Redis/PredisClientFactory.php
@@ -25,7 +25,7 @@ class PredisClientFactory
      */
     public static function create($params = null, $options = null, $sentinel_params = null)
     {
-        $discover_slaves = false;
+        $discover_slaves = true;
 
         // Make sure slave discovery from sentinels flag is set
         if (is_array($options) && isset($options['discover_slaves'])) {
@@ -44,7 +44,8 @@ class PredisClientFactory
 
             $masters = self::$sentinel->findMasters();
 
-            if (!empty($masters)) {
+            // Masters have been discovered and check slave discovery is requested.
+            if (!empty($masters) && true === $discover_slaves) {
                 $slaves = self::$sentinel->findSlaves();
             }
 


### PR DESCRIPTION
Added an option to the $options param that gets passed into PredisClientFactory::create() to ignore automatic slave discovery from Sentinel masters.
