### PR TITLE
Redis Driver ignores masters with null params

### DIFF
--- a/src/Bravo3/Orm/Drivers/Redis/PredisClientFactory.php
+++ b/src/Bravo3/Orm/Drivers/Redis/PredisClientFactory.php
@@ -58,6 +58,8 @@ class PredisClientFactory
                     $params,
                     $masters
                 );
+            } elseif ($masters) {
+                $redis_connections = $masters;
             }
 
             // Merge additional slaves discovered


### PR DESCRIPTION
Fix the issue of not merging discovered masters when params is null.
