### PR TITLE
Fix for RedisDriver payload encoding

### DIFF
--- a/src/Bravo3/Orm/Drivers/Redis/RedisDriver.php
+++ b/src/Bravo3/Orm/Drivers/Redis/RedisDriver.php
@@ -722,7 +722,7 @@ class RedisDriver implements DriverInterface, PubSubDriverInterface
             $payload = $this->client->getConnection()->read();
 
             $channel = ltrim($payload[2], self::SUBSCRIPTION_PATTERN);
-            $message = $payload[3];
+            $message = base64_decode($payload[3]);
 
             call_user_func(
                 $callback,
@@ -743,6 +743,6 @@ class RedisDriver implements DriverInterface, PubSubDriverInterface
      */
     public function publishMessage($channel, $message)
     {
-        return $this->client->publish($channel, $message);
+        return $this->client->publish($channel, base64_encode($message));
     }
 }

--- a/tests/Bravo3/Orm/Tests/Drivers/Redis/DummyPubSubDriver.php
+++ b/tests/Bravo3/Orm/Tests/Drivers/Redis/DummyPubSubDriver.php
@@ -18,7 +18,7 @@ class DummyPubSubDriver implements PubSubDriverInterface
 
     public function setMessage($message)
     {
-        $this->message = $message;
+        $this->message = base64_encode($message);
     }
 
     public function isPubSubSupported()
@@ -42,7 +42,7 @@ class DummyPubSubDriver implements PubSubDriverInterface
             $callback,
             [
                 'channel' => $this->channel,
-                'message' => $this->message,
+                'message' => base64_decode($this->message),
             ]
         );
     }


### PR DESCRIPTION
Fixed an issue with the Redis driver affecting PubSub mechanism as the message could contain unsupported characters for Redis.
