### PR TITLE
Modified pubsub channel name generation 

### DIFF
--- a/src/Bravo3/Orm/Drivers/PubSubDriverInterface.php
+++ b/src/Bravo3/Orm/Drivers/PubSubDriverInterface.php
@@ -3,7 +3,7 @@ namespace Bravo3\Orm\Drivers;
 
 interface PubSubDriverInterface
 {
-    const SUBSCRIPTION_PATTERN = 'BRAVO3_EVT-*';
+    const SUBSCRIPTION_PATTERN = 'BRAVO3_EVT';
 
     /**
      * Confirm that the driver supports Pub/Sub messaging.

--- a/src/Bravo3/Orm/Services/PubSubManager.php
+++ b/src/Bravo3/Orm/Services/PubSubManager.php
@@ -45,7 +45,7 @@ class PubSubManager
      */
     public function publish($channel, $message)
     {
-        return (bool) $this->driver->publishMessage(static::generateEventName($channel), $message);
+        return (bool) $this->driver->publishMessage($channel, $message);
     }
 
     /**


### PR DESCRIPTION
The driver should be responsible for handling the channel names. Abstracted out db pubsub channel naming to the driver class. PubSubManager is handling the user configurable channel name.
